### PR TITLE
backend: add API call to export calendar in ICS format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+# calendars
+*.ics

--- a/academic_helper/logic/schedule_export.py
+++ b/academic_helper/logic/schedule_export.py
@@ -1,0 +1,114 @@
+from academic_helper.models import ClassSchedule
+import arrow
+from ics import Calendar, Event
+
+
+# TODO: needs to be modeled in the DB
+_HUJI_SEMESTER_DATES = {
+    1: {
+        "begin": arrow.get(year=2019, month=10, day=27),
+        "end": arrow.get(year=2020, month=1, day=28),
+    },
+    2: {
+        "begin": arrow.get(year=2020, month=3, day=12),
+        "end": arrow.get(year=2020, month=6, day=30),
+    },
+}
+
+
+class ScheduleExportError(Exception):
+    pass
+
+
+class ScheduleExport:
+    def __init__(self, user):
+        self.user = user
+
+    def get_user_choices_as_events(self):
+        schedules = ClassSchedule.objects.filter(user=self.user)
+        data = []
+        for schedule_event in schedules:
+            course_name = schedule_event.group.occurrence.course.name
+            course_year = schedule_event.group.occurrence.year
+            course_number = schedule_event.group.occurrence.course.course_number
+            for event in schedule_event.group.courseclass_set.all():
+                data.append(
+                    dict(
+                        course_name=course_name,
+                        course_number=course_number,
+                        hall_name=event.hall.name,
+                        campus=event.hall.campus.name,
+                        department=schedule_event.group.occurrence.course.department.name,
+                        semester=event.semester,
+                        day=event.day,
+                        start_time=event.start_time,
+                        end_time=event.end_time,
+                        course_year=course_year,
+                    )
+                )
+        return data
+
+    def as_dict(self):
+        return self.get_user_choices_as_events()
+
+    def as_ical(self):
+        courses = self.get_user_choices_as_events()
+        events = self._get_ical_events(courses)
+        calendar = Calendar(events=events)
+        return calendar
+
+    def _get_ical_events(self, courses):
+        events = []
+        for course in courses:
+            time_range = self._get_all_events_for_course(course)
+            for event_begin in time_range:
+                event = Event()
+                event.name = course["course_name"]
+                event.begin = event_begin
+                event.end = event_begin.replace(
+                    hour=course["end_time"].hour,
+                    minute=course["end_time"].minute,
+                    second=0,
+                    year=course["course_year"],
+                )
+                event.location = f"{course['hall_name']}, {course['campus']}"
+                events.append(event)
+        return events
+
+    def _get_all_events_for_course(self, course):
+        if course["semester"] not in _HUJI_SEMESTER_DATES:
+            raise ScheduleExportError(
+                f'Unknown Semester encoding: {course["semester"]}'
+            )
+
+        semester_begin = _HUJI_SEMESTER_DATES[course["semester"]]["begin"]
+        semester_end = _HUJI_SEMESTER_DATES[course["semester"]]["end"]
+
+        course_begin = self._calculate_course_first_day(
+            semester_begin,
+            course["day"],
+            course["start_time"].hour,
+            course["start_time"].minute,
+        )
+        events = self._calculate_weekly_events(course_begin, semester_end)
+
+        return events
+
+    def _calculate_course_first_day(
+        self, begin_date, event_day, event_hour, event_minute
+    ):
+        return begin_date.shift(weekday=(event_day - 2) % 7).replace(
+            hour=event_hour, minute=event_minute, second=0
+        )
+
+    def _calculate_weekly_events(self, begin_date, end_date):
+        if end_date <= begin_date:
+            raise ScheduleExportError(
+                f"Begin date must be smaller than End date: begin_date={begin_date}, end_date={end_date}"
+            )
+        dates = []
+        current = begin_date
+        while current <= end_date:
+            dates.append(current)
+            current = current.shift(weeks=1)
+        return dates

--- a/academic_helper/tests/test_rest_calls.py
+++ b/academic_helper/tests/test_rest_calls.py
@@ -1,8 +1,12 @@
 from django.test import Client
-from django.test import TestCase
-
+from django.test import TestCase, RequestFactory
+import json
+import io
+from ics import Calendar
 from academic_helper.management import init_data
 from academic_helper.management.init_data import create_all
+from academic_helper.views.schedule import ScheduleView
+from academic_helper.models import CoursistUser
 
 urls_to_get = [
     "",
@@ -20,9 +24,14 @@ urls_to_get = [
 
 
 class TestRestCalls(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = CoursistUser.objects.create_user(
+            username="test_user", email="test_user@test_user.com", password="nuclear"
+        )
+
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
         create_all()
 
     def test_get_urls(self):
@@ -30,6 +39,36 @@ class TestRestCalls(TestCase):
         for url in urls_to_get:
             response = client.get(url, follow=True)
             self.assertEquals(response.status_code, 200)
+
+    def test_get_schedule_export_empty(self):
+
+        request = self.factory.get("/schedule", {"download": "json"})
+        request.user = self.user
+        response = ScheduleView.as_view()(request)
+
+        self.assertEquals(response.status_code, 200)
+        self.assertIn("attachment; filename=", response.get("Content-Disposition"))
+        self.assertEqual(response["content-type"], "application/json")
+
+        result_bytes = b"".join(response.streaming_content)
+        result = json.loads(result_bytes)
+        self.assertEquals(result, json.loads(b"[]"))
+
+    def test_get_schedule_export_empty_ical(self):
+
+        request = self.factory.get("/schedule", {"download": "ical"})
+        request.user = self.user
+        response = ScheduleView.as_view()(request)
+
+        self.assertEquals(response.status_code, 200)
+        self.assertIn("attachment; filename=", response.get("Content-Disposition"))
+        self.assertEqual(response["content-type"], "text/calendar")
+
+        result_bytes = b"".join(response.streaming_content)
+        expected_result = io.BytesIO()
+        expected_result.writelines([line.encode() for line in Calendar()])
+        expected_result.seek(0)
+        self.assertEquals(result_bytes, expected_result.read())
 
     def test_post_urls(self):
         pass

--- a/academic_helper/views/schedule.py
+++ b/academic_helper/views/schedule.py
@@ -1,8 +1,9 @@
 import json
-
+from io import BytesIO
 from django.db.models import Q
 from django.http import JsonResponse, HttpResponseBadRequest
-
+from django.http import FileResponse
+from django.core.serializers.json import DjangoJSONEncoder
 from academic_helper.logic.errors import UserNotLoggedInError, CourseNotFoundError
 from academic_helper.logic.schedule import (
     set_user_schedule_group,
@@ -10,9 +11,14 @@ from academic_helper.logic.schedule import (
     get_all_classes,
     del_user_schedule_groups,
 )
+
+from academic_helper.logic.schedule_export import ScheduleExport
 from academic_helper.models.course import Course
 from academic_helper.views.basic import ExtendedViewMixin
+import logging
+import arrow
 
+LOG = logging.getLogger(__name__)
 SCHEDULE_COOKIE = "schedule"
 
 
@@ -30,7 +36,25 @@ class ScheduleView(ExtendedViewMixin):
             # get_context_data, which already used this cookie
             response.delete_cookie(SCHEDULE_COOKIE)
 
-        return response
+        if request.GET.get("download") == "ical":
+            ical = ScheduleExport(user=self.user).as_ical()
+            buffer = BytesIO()
+            buffer.writelines([line.encode() for line in ical])
+            buffer.seek(0)
+            return FileResponse(
+                buffer, as_attachment=True, filename=f"coursist_export_{self.user}_{arrow.utcnow()}.ics",
+            )
+        elif request.GET.get("download") == "json":
+            event_json = ScheduleExport(user=self.user).as_dict()
+            buffer = BytesIO()
+            buffer.write(json.dumps(event_json, indent=4, sort_keys=True, cls=DjangoJSONEncoder).encode())
+            buffer.seek(0)
+            return FileResponse(
+                buffer, as_attachment=True, filename=f"coursist_export_{self.user}_{arrow.utcnow()}.json",
+            )
+
+        else:
+            return response
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -50,7 +74,7 @@ class ScheduleView(ExtendedViewMixin):
             Q(name__icontains=search_val) | Q(course_number__icontains=search_val)
         ).order_by("course_number")[:10]
         serialized = [c.as_dict for c in courses]
-        return JsonResponse({"status": "success", "courses": serialized}, json_dumps_params={"ensure_ascii": False})
+        return JsonResponse({"status": "success", "courses": serialized}, json_dumps_params={"ensure_ascii": False},)
 
     def get_classes(self, course_number):
         if not course_number.isdigit():
@@ -58,7 +82,7 @@ class ScheduleView(ExtendedViewMixin):
         try:
             groups = get_all_classes(course_number)
             return JsonResponse({"status": "success", "groups": groups})
-        except CourseNotFoundError as e:
+        except CourseNotFoundError:
             return JsonResponse({"status": "error", "message": "Course not found"})
 
     def on_user_group_choice(self, choice):
@@ -81,13 +105,13 @@ class ScheduleView(ExtendedViewMixin):
         if "search_val" in request.POST:
             search_val = request.POST["search_val"]
             return self.on_search_course(search_val)
-        if "course_number" in request.POST:
+        elif "course_number" in request.POST:
             course_number = request.POST["course_number"]
             return self.get_classes(course_number)
-        if "group_choice" in request.POST:
+        elif "group_choice" in request.POST:
             choice = request.POST["group_choice"]
             return self.on_user_group_choice(choice)
-        if "groups_to_del" in request.POST:
+        elif "groups_to_del" in request.POST:
             choices = json.loads(request.POST["groups_to_del"])["group_ids"]
             return self.on_user_delete_groups(choices)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ sentry-sdk==0.14.4
 django-contrib-comments==1.9.2
 django-s3-storage==0.13.2
 watchtower==0.7.3
+arrow==0.14.7
+ics==0.7


### PR DESCRIPTION
The new route is at: /schedule, with query parameter `download`:
1. /schedule/?download=ical
Will download the existing user scheduled courses in ICS format
(iCalendar)

2. /schedule/?download=json
Will download the existing user scheduled courses in JSON format
but not as repeating events (just the canonical dates)

The ICS format can be easily exported to google calendar, outlook, etc.

No FE here (yet) - would be helpful if you could help testing it out, I tested the basic functionally manually (one course, 2 courses, etc) - and imported it to google calendar. I didn't test all the edge cases: end/begin of semester course, etc.



### How to run
When logged in just add in your browser /schedule/?download=ical
Go to google calendar -> press add new calendar -> press import






Closes https://github.com/asaf-kali/coursist/issues/94
