### PR TITLE
Add CI with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: coursist unit tests and linting
+on:
+  push:
+    branches: 
+    - master
+    - develop
+  pull_request:
+    branches: 
+    - master
+    - develop
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install python dependencies
+      run: |
+        pip install -r requirements-dev.txt
+        pip install -r requirements.txt
+    - name: Black Code Formatter
+      uses: lgeiger/black-action@v1.0.1
+      with:
+        args: ". --check -l 120"
+    - name: Run unit tests
+      run: |
+        python manage.py migrate
+        python manage.py test


### PR DESCRIPTION
On each commit to master/develop:
1. Run `black` with `--check`, will fail if not all files are formatted.
2. Run unit tests, will fail the pipeline if any of them fails.


@asaf-kali note one of the unit tests failed - I fixed it - not sure what was the reason (it happens on `develop` too I assume).


Closes https://github.com/asaf-kali/coursist/issues/118#issue-654358143