### PR TITLE
restore missing rule for active autocomplete entry

### DIFF
--- a/static/styles/master.css
+++ b/static/styles/master.css
@@ -183,3 +183,9 @@ div.comment {
 .autocomplete-items div:hover {
     background-color: #e9e9e9;
 }
+
+.autocomplete-active {
+    /*when navigating through the items using the arrow keys:*/
+    background-color: DodgerBlue !important;
+    color: #ffffff;
+}


### PR DESCRIPTION
The CSS rule that highlights the active autocomplete list entry was missing in develop branch, but it exists both in master and on the live site, so I added it back.